### PR TITLE
trace: aggregate in worker and simplify trace pipeline

### DIFF
--- a/moonpad/src/moon.ts
+++ b/moonpad/src/moon.ts
@@ -21,6 +21,7 @@ import * as vscodeUri from "vscode-uri";
 import * as mfs from "./mfs";
 import moonrunWorker from "./moonrun-worker?worker&inline";
 import template from "./template.mbt?raw";
+import type { TraceResult, TraceRunOutput } from "./trace-types";
 
 const MOON_TEST_DELIMITER_BEGIN = "----- BEGIN MOON TEST RESULT -----";
 const MOON_TEST_DELIMITER_END = "----- END MOON TEST RESULT -----";
@@ -249,26 +250,6 @@ type TestResult = {
   test_name: string;
   message: string;
 };
-
-type TraceResult = {
-  name: string;
-  value: string;
-  line: number;
-  start_column: number;
-  end_column: number;
-  filepath?: string;
-  hit: number;
-};
-
-type TraceRunOutput =
-  | {
-      kind: "trace-delta";
-      entries: TraceResult[];
-    }
-  | {
-      kind: "stdout-batch";
-      lines: string[];
-    };
 
 function parseTestOutputTransformStream(): TransformStream<string, TestOutput> {
   let isInSection = false;

--- a/moonpad/src/moon.ts
+++ b/moonpad/src/moon.ts
@@ -250,6 +250,30 @@ type TestResult = {
   message: string;
 };
 
+type TraceRunOptions = {
+  signal?: AbortSignal;
+};
+
+type TraceResult = {
+  name: string;
+  value: string;
+  line: number;
+  start_column: number;
+  end_column: number;
+  filepath?: string;
+  hit: number;
+};
+
+type TraceRunOutput =
+  | {
+      kind: "trace-delta";
+      entries: TraceResult[];
+    }
+  | {
+      kind: "stdout-batch";
+      lines: string[];
+    };
+
 function parseTestOutputTransformStream(): TransformStream<string, TestOutput> {
   let isInSection = false;
   let stdout = "";
@@ -297,6 +321,90 @@ function run(js: Uint8Array): ReadableStream<string> {
   });
 }
 
+function runTrace(
+  js: Uint8Array,
+  options: TraceRunOptions = {},
+): ReadableStream<TraceRunOutput> {
+  const worker = new moonrunWorker();
+  const pending: TraceRunOutput[] = [];
+  let isDone = false;
+  let pendingError: Error | undefined = undefined;
+  let isClosed = false;
+  let controllerRef:
+    | ReadableStreamDefaultController<TraceRunOutput>
+    | undefined;
+  let detachAbortListener: (() => void) | undefined = undefined;
+  const closeWorker = () => {
+    if (isClosed) return;
+    isClosed = true;
+    detachAbortListener?.();
+    detachAbortListener = undefined;
+    worker.terminate();
+  };
+  const flush = () => {
+    const controller = controllerRef;
+    if (!controller || isClosed) return;
+    if (pendingError) {
+      closeWorker();
+      controller.error(pendingError);
+      return;
+    }
+    while (pending.length > 0 && (controller.desiredSize ?? 0) > 0) {
+      controller.enqueue(pending.shift()!);
+    }
+    if (isDone && pending.length === 0) {
+      closeWorker();
+      controller.close();
+    }
+  };
+  worker.onmessage = (e: MessageEvent<TraceRunOutput | null | Error>) => {
+    if (isClosed) return;
+    if (e.data instanceof Error) {
+      pendingError = e.data;
+      flush();
+      return;
+    }
+    if (e.data === null) {
+      isDone = true;
+      flush();
+      return;
+    }
+    pending.push(e.data);
+    flush();
+  };
+  return new ReadableStream<TraceRunOutput>({
+    start(controller) {
+      controllerRef = controller;
+      if (options.signal) {
+        if (options.signal.aborted) {
+          closeWorker();
+          controller.close();
+          return;
+        }
+        const abortHandler = () => {
+          closeWorker();
+          controller.close();
+        };
+        options.signal.addEventListener("abort", abortHandler, { once: true });
+        detachAbortListener = () => {
+          options.signal?.removeEventListener("abort", abortHandler);
+        };
+      }
+      worker.postMessage({
+        js,
+        traceAggregate: true,
+      });
+      flush();
+    },
+    pull() {
+      flush();
+    },
+    cancel() {
+      closeWorker();
+    },
+  });
+}
+
 function test(js: Uint8Array): ReadableStream<TestOutput> {
   return run(js).pipeThrough(parseTestOutputTransformStream());
 }
@@ -306,4 +414,5 @@ function init(factory: () => Worker) {
   mooncWorkerFactory = factory;
 }
 
-export { compile, init, run, test };
+export { compile, init, run, runTrace, test };
+export type { TraceResult, TraceRunOutput };

--- a/moonpad/src/moon.ts
+++ b/moonpad/src/moon.ts
@@ -250,10 +250,6 @@ type TestResult = {
   message: string;
 };
 
-type TraceRunOptions = {
-  signal?: AbortSignal;
-};
-
 type TraceResult = {
   name: string;
   value: string;
@@ -303,7 +299,7 @@ function parseTestOutputTransformStream(): TransformStream<string, TestOutput> {
 
 function run(js: Uint8Array): ReadableStream<string> {
   const worker = new moonrunWorker();
-  worker.postMessage(js);
+  worker.postMessage({ js });
   return new ReadableStream<string>({
     start(controller) {
       worker.onmessage = (e: MessageEvent<string | null | Error>) => {
@@ -323,81 +319,34 @@ function run(js: Uint8Array): ReadableStream<string> {
 
 function runTrace(
   js: Uint8Array,
-  options: TraceRunOptions = {},
 ): ReadableStream<TraceRunOutput> {
   const worker = new moonrunWorker();
-  const pending: TraceRunOutput[] = [];
-  let isDone = false;
-  let pendingError: Error | undefined = undefined;
   let isClosed = false;
-  let controllerRef:
-    | ReadableStreamDefaultController<TraceRunOutput>
-    | undefined;
-  let detachAbortListener: (() => void) | undefined = undefined;
   const closeWorker = () => {
     if (isClosed) return;
     isClosed = true;
-    detachAbortListener?.();
-    detachAbortListener = undefined;
     worker.terminate();
-  };
-  const flush = () => {
-    const controller = controllerRef;
-    if (!controller || isClosed) return;
-    if (pendingError) {
-      closeWorker();
-      controller.error(pendingError);
-      return;
-    }
-    while (pending.length > 0 && (controller.desiredSize ?? 0) > 0) {
-      controller.enqueue(pending.shift()!);
-    }
-    if (isDone && pending.length === 0) {
-      closeWorker();
-      controller.close();
-    }
-  };
-  worker.onmessage = (e: MessageEvent<TraceRunOutput | null | Error>) => {
-    if (isClosed) return;
-    if (e.data instanceof Error) {
-      pendingError = e.data;
-      flush();
-      return;
-    }
-    if (e.data === null) {
-      isDone = true;
-      flush();
-      return;
-    }
-    pending.push(e.data);
-    flush();
   };
   return new ReadableStream<TraceRunOutput>({
     start(controller) {
-      controllerRef = controller;
-      if (options.signal) {
-        if (options.signal.aborted) {
+      worker.onmessage = (e: MessageEvent<TraceRunOutput | null | Error>) => {
+        if (isClosed) return;
+        if (e.data instanceof Error) {
+          closeWorker();
+          controller.error(e.data);
+          return;
+        }
+        if (e.data === null) {
           closeWorker();
           controller.close();
           return;
         }
-        const abortHandler = () => {
-          closeWorker();
-          controller.close();
-        };
-        options.signal.addEventListener("abort", abortHandler, { once: true });
-        detachAbortListener = () => {
-          options.signal?.removeEventListener("abort", abortHandler);
-        };
-      }
+        controller.enqueue(e.data);
+      };
       worker.postMessage({
         js,
         traceAggregate: true,
       });
-      flush();
-    },
-    pull() {
-      flush();
     },
     cancel() {
       closeWorker();

--- a/moonpad/src/moonbit-mode.ts
+++ b/moonpad/src/moonbit-mode.ts
@@ -34,7 +34,6 @@ type initParams = {
 type TraceModelState = {
   decorations: string[];
   aborter?: AbortController;
-  runToken: number;
   clearOnEdit?: monaco.IDisposable;
 };
 
@@ -43,7 +42,6 @@ const sharedTraceStates = new Map<string, TraceModelState>();
 function createTraceModelState(model: monaco.editor.ITextModel): TraceModelState {
   const state: TraceModelState = {
     decorations: [],
-    runToken: 0,
   };
   model.onWillDispose(() => {
     state.aborter?.abort();
@@ -1025,21 +1023,13 @@ function traceCommandFactory() {
     const state = sharedTraceStates.get(modelId) ?? createTraceModelState(model);
     state.clearOnEdit?.dispose();
     state.clearOnEdit = undefined;
-    if (state.decorations.length > 0) {
-      state.decorations = model.deltaDecorations(state.decorations, []);
-    }
+    state.decorations = model.deltaDecorations(state.decorations, []);
     state.aborter?.abort();
     const aborter = new AbortController();
     state.aborter = aborter;
-    const runToken = state.runToken + 1;
-    state.runToken = runToken;
     const isCurrentRun = () => {
       const current = sharedTraceStates.get(modelId);
-      return (
-        current !== undefined &&
-        current.runToken === runToken &&
-        current.aborter === aborter
-      );
+      return current !== undefined && current.aborter === aborter;
     };
     const name = muri.path.split("/").at(-1)!;
     const result = await moon.compile({
@@ -1080,9 +1070,7 @@ function traceCommandFactory() {
         };
         try {
           await moon
-            .runTrace(js, {
-              signal: aborter.signal,
-            })
+            .runTrace(js)
             .pipeTo(
               new WritableStream<moon.TraceRunOutput>({
                 write(chunk) {

--- a/moonpad/src/moonbit-mode.ts
+++ b/moonpad/src/moonbit-mode.ts
@@ -31,6 +31,29 @@ type initParams = {
   codeLensFilter?: (lens: lsp.CodeLens) => boolean;
 };
 
+type TraceModelState = {
+  decorations: string[];
+  aborter?: AbortController;
+  runToken: number;
+  clearOnEdit?: monaco.IDisposable;
+};
+
+const sharedTraceStates = new Map<string, TraceModelState>();
+
+function createTraceModelState(model: monaco.editor.ITextModel): TraceModelState {
+  const state: TraceModelState = {
+    decorations: [],
+    runToken: 0,
+  };
+  model.onWillDispose(() => {
+    state.aborter?.abort();
+    state.clearOnEdit?.dispose();
+    sharedTraceStates.delete(model.id);
+  });
+  sharedTraceStates.set(model.id, state);
+  return state;
+}
+
 function ensureDirSync(fs: mfs.MFS, path: string) {
   if (!fs.existsSync(path)) {
     fs.mkdirSync(path, { recursive: true });
@@ -982,133 +1005,190 @@ function init(params: initParams): typeof moon {
     codeLensProvider,
   );
   moon.init(mooncWorkerFactory);
+  const traceMain = traceCommandFactory();
   monaco.editor.registerCommand("moonbit-lsp/trace-main", async (_, param) => {
-    traceCommandFactory()(param.fileUri);
+    const fileUri =
+      (param as { fileUri?: string; uri?: string } | undefined)?.fileUri ??
+      (param as { fileUri?: string; uri?: string } | undefined)?.uri;
+    if (!fileUri) return;
+    traceMain(fileUri);
   });
   return moon;
 }
 
 function traceCommandFactory() {
-  const decorations = new Map<string, string[]>();
   return async (uri: string): Promise<string | undefined> => {
     const muri = monaco.Uri.parse(uri);
     const model = monaco.editor.getModel(muri);
     if (model === null) return;
+    const modelId = model.id;
+    const state = sharedTraceStates.get(modelId) ?? createTraceModelState(model);
+    state.clearOnEdit?.dispose();
+    state.clearOnEdit = undefined;
+    if (state.decorations.length > 0) {
+      state.decorations = model.deltaDecorations(state.decorations, []);
+    }
+    state.aborter?.abort();
+    const aborter = new AbortController();
+    state.aborter = aborter;
+    const runToken = state.runToken + 1;
+    state.runToken = runToken;
+    const isCurrentRun = () => {
+      const current = sharedTraceStates.get(modelId);
+      return (
+        current !== undefined &&
+        current.runToken === runToken &&
+        current.aborter === aborter
+      );
+    };
     const name = muri.path.split("/").at(-1)!;
     const result = await moon.compile({
       libInputs: [[name, model.getValue()]],
       enableValueTracing: true,
     });
+    if (!isCurrentRun()) return;
     switch (result.kind) {
       case "error": {
+        if (isCurrentRun()) {
+          state.aborter = undefined;
+        }
         console.error(result.diagnostics);
         return;
       }
       case "success": {
         const js = result.js;
-        const stdoutStream = moon.run(js);
-        const lines = await collect(stdoutStream);
-        const { traceResults, stdout } = parseTraceOutput(lines);
-        const oldDecorations = decorations.get(model.id) ?? [];
-        const newDecorations = renderTraceResults(
-          model,
-          oldDecorations,
-          traceResults,
-        );
-        decorations.set(model.id, newDecorations);
-        let d = model.onDidChangeContent(() => {
-          decorations.set(model.id, model.deltaDecorations(newDecorations, []));
-          d.dispose();
+        const traceResults = new Map<string, TraceResult>();
+        const stdoutLines: string[] = [];
+        const applyTraceResults = () => {
+          if (!isCurrentRun()) return;
+          const currentTraceResults = [...traceResults.values()];
+          const filteredTraceResults = currentTraceResults.filter((res) =>
+            traceResultMatchesModel(res, muri.path, name),
+          );
+          const traceResultsToRender =
+            filteredTraceResults.length > 0 || currentTraceResults.length === 0
+              ? filteredTraceResults
+              : currentTraceResults;
+          const normalizedTraceResults = dedupeTraceResultsForRender(
+            traceResultsToRender,
+          );
+          state.decorations = renderTraceResults(
+            model,
+            state.decorations,
+            normalizedTraceResults,
+          );
+        };
+        try {
+          await moon
+            .runTrace(js, {
+              signal: aborter.signal,
+            })
+            .pipeTo(
+              new WritableStream<moon.TraceRunOutput>({
+                write(chunk) {
+                  if (chunk.kind === "stdout-batch") {
+                    stdoutLines.push(...chunk.lines);
+                    return;
+                  }
+                  for (const entry of chunk.entries) {
+                    traceResults.set(traceKey(entry), entry);
+                  }
+                  applyTraceResults();
+                },
+              }),
+              { signal: aborter.signal },
+            );
+        } catch (error) {
+          if (isAbortError(error)) {
+            if (isCurrentRun()) state.aborter = undefined;
+            return;
+          }
+          throw error;
+        }
+        if (!isCurrentRun()) return;
+        state.aborter = undefined;
+        applyTraceResults();
+        state.clearOnEdit = model.onDidChangeContent(() => {
+          state.decorations = model.deltaDecorations(state.decorations, []);
+          state.clearOnEdit?.dispose();
+          state.clearOnEdit = undefined;
         });
-        return stdout;
+        return stdoutLines.join("\n");
       }
     }
   };
 }
 
-type TraceResult = {
-  name: string;
-  value: string;
-  line: number;
-  start_column: number;
-  end_column: number;
-  hit: number;
-};
+type TraceResult = moon.TraceResult;
 
-const TRACING_START = "######MOONBIT_VALUE_TRACING_START######";
-const TRACING_CONTENT_START = "######MOONBIT_VALUE_TRACING_CONTENT_START######";
-
-const TRACING_END = "######MOONBIT_VALUE_TRACING_END######";
-const TRACING_CONTENT_END = "######MOONBIT_VALUE_TRACING_CONTENT_END######";
-
-async function collect(s: ReadableStream<string>): Promise<string[]> {
-  const lines: string[] = [];
-  await s.pipeTo(
-    new WritableStream({
-      write(chunk) {
-        lines.push(chunk);
-      },
-    }),
-  );
-  return lines;
-}
-
-function traceKey(trace: TraceResult): string {
+function traceKey(
+  trace: Pick<
+    TraceResult,
+    "name" | "line" | "start_column" | "end_column" | "filepath"
+  >,
+): string {
   return JSON.stringify({
     name: trace.name,
     line: trace.line,
     start_column: trace.start_column,
     end_column: trace.end_column,
+    filepath: trace.filepath ?? "",
   });
 }
 
-function parseTraceOutput(lines: string[]): {
-  traceResults: TraceResult[];
-  stdout: string;
-} {
-  const results = new Map<string, TraceResult>();
-  const stdoutLines: string[] = [];
-  let isInTrace = false;
-  let isInTraceContent = false;
-  let lastResultKey: string | undefined = undefined;
-  for (const line of lines) {
-    if (line === TRACING_START) {
-      isInTrace = true;
-      continue;
-    } else if (line === TRACING_END) {
-      isInTrace = false;
-      continue;
-    } else if (line === TRACING_CONTENT_START) {
-      isInTraceContent = true;
-      continue;
-    } else if (line === TRACING_CONTENT_END) {
-      isInTraceContent = false;
+function isAbortError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: string }).name === "AbortError"
+  );
+}
+
+function traceResultMatchesModel(
+  res: TraceResult,
+  modelPath: string,
+  modelName: string,
+): boolean {
+  const filepath = res.filepath;
+  if (!filepath) return true;
+  return (
+    filepath === modelPath ||
+    filepath === modelName ||
+    filepath.endsWith(`/${modelName}`) ||
+    filepath.endsWith(`\\${modelName}`)
+  );
+}
+
+function formatTraceValue(value: string): string {
+  const oneLine = value.split("\n").join("\\n");
+  const maxLen = 160;
+  if (oneLine.length <= maxLen) return oneLine;
+  return `${oneLine.slice(0, maxLen)}...`;
+}
+
+function dedupeTraceResultsForRender(results: TraceResult[]): TraceResult[] {
+  const deduped = new Map<string, TraceResult>();
+  for (const res of results) {
+    const key = JSON.stringify({
+      name: res.name,
+      line: res.line,
+      start_column: res.start_column,
+      end_column: res.end_column,
+    });
+    const prev = deduped.get(key);
+    if (!prev) {
+      deduped.set(key, { ...res });
       continue;
     }
-    if (isInTraceContent) {
-      if (!lastResultKey) continue;
-      const value = line;
-      const res = results.get(lastResultKey);
-      if (!res) continue;
-      res.value = value;
-    } else if (isInTrace) {
-      const j = JSON.parse(line);
-      const key = traceKey(j);
-      lastResultKey = key;
-      const res = results.get(key);
-      if (res === undefined) {
-        results.set(key, { ...j, hit: 1 });
-      } else {
-        results.set(key, { ...j, hit: res.hit + 1 });
-      }
-    } else {
-      stdoutLines.push(line);
-    }
+    deduped.set(key, {
+      ...prev,
+      value: res.value || prev.value,
+      hit: prev.hit + res.hit,
+      filepath: prev.filepath ?? res.filepath,
+    });
   }
-  return {
-    traceResults: [...results.values()],
-    stdout: stdoutLines.join("\n"),
-  };
+  return [...deduped.values()];
 }
 
 function renderTraceResults(
@@ -1117,14 +1197,25 @@ function renderTraceResults(
   results: TraceResult[],
 ): string[] {
   const newDecorations: monaco.editor.IModelDeltaDecoration[] = [];
+  const lineCount = model.getLineCount();
   for (const res of results) {
     const line = res.line;
-    const character = model.getLineLastNonWhitespaceColumn(line);
+    if (line < 1 || line > lineCount) continue;
+    const maxColumn = model.getLineMaxColumn(line);
+    const nonWhitespace = model.getLineLastNonWhitespaceColumn(line);
+    const character = nonWhitespace > 0 ? nonWhitespace : 1;
+    const rangeStart = Math.min(maxColumn - 1, character);
+    const startColumn = Math.max(1, rangeStart);
+    const endColumn = Math.min(maxColumn, startColumn + 1);
+    if (endColumn <= startColumn) continue;
+    const content = `${res.name} = ${formatTraceValue(res.value)}${
+      res.hit > 1 ? ` (${res.hit} hits)` : ""
+    }`;
     newDecorations.push({
-      range: new monaco.Range(line, character - 1, line, character),
+      range: new monaco.Range(line, startColumn, line, endColumn),
       options: {
         after: {
-          content: `${res.name} = ${res.value}${res.hit > 1 ? ` (${res.hit} hits)` : ""}`,
+          content,
           inlineClassName: "moonbit-trace",
           cursorStops: monaco.editor.InjectedTextCursorStops.None,
         },

--- a/moonpad/src/moonbit-mode.ts
+++ b/moonpad/src/moonbit-mode.ts
@@ -1148,13 +1148,6 @@ function traceResultMatchesModel(
   );
 }
 
-function formatTraceValue(value: string): string {
-  const oneLine = value.split("\n").join("\\n");
-  const maxLen = 160;
-  if (oneLine.length <= maxLen) return oneLine;
-  return `${oneLine.slice(0, maxLen)}...`;
-}
-
 function dedupeTraceResultsForRender(results: TraceResult[]): TraceResult[] {
   const deduped = new Map<string, TraceResult>();
   for (const res of results) {
@@ -1185,25 +1178,14 @@ function renderTraceResults(
   results: TraceResult[],
 ): string[] {
   const newDecorations: monaco.editor.IModelDeltaDecoration[] = [];
-  const lineCount = model.getLineCount();
   for (const res of results) {
     const line = res.line;
-    if (line < 1 || line > lineCount) continue;
-    const maxColumn = model.getLineMaxColumn(line);
-    const nonWhitespace = model.getLineLastNonWhitespaceColumn(line);
-    const character = nonWhitespace > 0 ? nonWhitespace : 1;
-    const rangeStart = Math.min(maxColumn - 1, character);
-    const startColumn = Math.max(1, rangeStart);
-    const endColumn = Math.min(maxColumn, startColumn + 1);
-    if (endColumn <= startColumn) continue;
-    const content = `${res.name} = ${formatTraceValue(res.value)}${
-      res.hit > 1 ? ` (${res.hit} hits)` : ""
-    }`;
+    const character = model.getLineLastNonWhitespaceColumn(line);
     newDecorations.push({
-      range: new monaco.Range(line, startColumn, line, endColumn),
+      range: new monaco.Range(line, character - 1, line, character),
       options: {
         after: {
-          content,
+          content: `${res.name} = ${res.value}${res.hit > 1 ? ` (${res.hit} hits)` : ""}`,
           inlineClassName: "moonbit-trace",
           cursorStops: monaco.editor.InjectedTextCursorStops.None,
         },

--- a/moonpad/src/moonrun-worker.ts
+++ b/moonpad/src/moonrun-worker.ts
@@ -14,19 +14,11 @@
  * limitations under the License.
  */
 
+import type { TraceResult } from "./trace-types";
+
 type RunRequest = {
   js: Uint8Array;
   traceAggregate?: boolean;
-};
-
-type TraceResult = {
-  name: string;
-  value: string;
-  line: number;
-  start_column: number;
-  end_column: number;
-  filepath?: string;
-  hit: number;
 };
 
 const TRACING_START = "######MOONBIT_VALUE_TRACING_START######";

--- a/moonpad/src/moonrun-worker.ts
+++ b/moonpad/src/moonrun-worker.ts
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-type RunRequest =
-  | Uint8Array
-  | {
-      js: Uint8Array;
-      traceAggregate?: boolean;
-    };
+type RunRequest = {
+  js: Uint8Array;
+  traceAggregate?: boolean;
+};
 
 type TraceResult = {
   name: string;
@@ -31,16 +29,6 @@ type TraceResult = {
   hit: number;
 };
 
-type TraceWorkerMessage =
-  | {
-      kind: "trace-delta";
-      entries: TraceResult[];
-    }
-  | {
-      kind: "stdout-batch";
-      lines: string[];
-    };
-
 const TRACING_START = "######MOONBIT_VALUE_TRACING_START######";
 const TRACING_CONTENT_START = "######MOONBIT_VALUE_TRACING_CONTENT_START######";
 const TRACING_END = "######MOONBIT_VALUE_TRACING_END######";
@@ -49,16 +37,11 @@ const TRACE_FLUSH_INTERVAL_MS = 16;
 const TRACE_FLUSH_EVERY_COMMITS = 32;
 
 self.onmessage = async (e: MessageEvent<RunRequest>) => {
-  const data = e.data;
-  if (data instanceof Uint8Array) {
-    runJs(data);
+  if (e.data.traceAggregate) {
+    runJsAggregate(e.data.js);
     return;
   }
-  if (data.traceAggregate) {
-    runJsAggregate(data.js);
-    return;
-  }
-  runJs(data.js);
+  runJs(e.data.js);
 };
 
 async function runJs(js: Uint8Array) {
@@ -102,7 +85,6 @@ function traceKey(
 
 type WorkerTraceParseState = {
   section: "stdout" | "meta" | "value";
-  pendingChunkLine: string;
   pendingValueLines: string[];
   lastResultKey: string | undefined;
   results: Map<string, TraceResult>;
@@ -120,7 +102,6 @@ async function runJsAggregate(js: Uint8Array) {
   );
   const state: WorkerTraceParseState = {
     section: "stdout",
-    pendingChunkLine: "",
     pendingValueLines: [],
     lastResultKey: undefined,
     results: new Map(),
@@ -129,23 +110,20 @@ async function runJsAggregate(js: Uint8Array) {
     flushTimer: undefined,
     commitsSinceFlush: 0,
   };
-  const post = (message: TraceWorkerMessage) => {
-    self.postMessage(message);
-  };
   const flushNow = () => {
     if (state.flushTimer !== undefined) {
       clearTimeout(state.flushTimer);
       state.flushTimer = undefined;
     }
     if (state.pendingDeltas.size > 0) {
-      post({
+      self.postMessage({
         kind: "trace-delta",
         entries: [...state.pendingDeltas.values()],
       });
       state.pendingDeltas.clear();
     }
     if (state.pendingStdout.length > 0) {
-      post({
+      self.postMessage({
         kind: "stdout-batch",
         lines: state.pendingStdout,
       });
@@ -227,19 +205,13 @@ async function runJsAggregate(js: Uint8Array) {
     scheduleFlush();
   };
   const feedTraceChunk = (chunk: string) => {
-    if (
-      !chunk.includes("\n") &&
-      !chunk.includes("\r") &&
-      state.pendingChunkLine === ""
-    ) {
-      feedTraceLine(chunk);
-      return;
-    }
-    const text = state.pendingChunkLine + chunk;
-    const lines = text.split(/\r?\n/);
-    state.pendingChunkLine = lines.pop() ?? "";
-    for (const line of lines) {
-      feedTraceLine(line);
+    const lines = chunk.split(/\r?\n/);
+    const lastIndex =
+      chunk.endsWith("\n") || chunk.endsWith("\r")
+        ? lines.length - 1
+        : lines.length;
+    for (let i = 0; i < lastIndex; i += 1) {
+      feedTraceLine(lines[i]!);
     }
   };
 
@@ -256,10 +228,6 @@ async function runJsAggregate(js: Uint8Array) {
     self.postMessage(e);
     return;
   } finally {
-    if (state.pendingChunkLine.length > 0) {
-      feedTraceLine(state.pendingChunkLine);
-      state.pendingChunkLine = "";
-    }
     flushNow();
     URL.revokeObjectURL(jsUrl);
     globalThis.console.log = oldLog;

--- a/moonpad/src/moonrun-worker.ts
+++ b/moonpad/src/moonrun-worker.ts
@@ -14,8 +14,51 @@
  * limitations under the License.
  */
 
-self.onmessage = async (e: MessageEvent<Uint8Array>) => {
-  runJs(e.data);
+type RunRequest =
+  | Uint8Array
+  | {
+      js: Uint8Array;
+      traceAggregate?: boolean;
+    };
+
+type TraceResult = {
+  name: string;
+  value: string;
+  line: number;
+  start_column: number;
+  end_column: number;
+  filepath?: string;
+  hit: number;
+};
+
+type TraceWorkerMessage =
+  | {
+      kind: "trace-delta";
+      entries: TraceResult[];
+    }
+  | {
+      kind: "stdout-batch";
+      lines: string[];
+    };
+
+const TRACING_START = "######MOONBIT_VALUE_TRACING_START######";
+const TRACING_CONTENT_START = "######MOONBIT_VALUE_TRACING_CONTENT_START######";
+const TRACING_END = "######MOONBIT_VALUE_TRACING_END######";
+const TRACING_CONTENT_END = "######MOONBIT_VALUE_TRACING_CONTENT_END######";
+const TRACE_FLUSH_INTERVAL_MS = 16;
+const TRACE_FLUSH_EVERY_COMMITS = 32;
+
+self.onmessage = async (e: MessageEvent<RunRequest>) => {
+  const data = e.data;
+  if (data instanceof Uint8Array) {
+    runJs(data);
+    return;
+  }
+  if (data.traceAggregate) {
+    runJsAggregate(data.js);
+    return;
+  }
+  runJs(data.js);
 };
 
 async function runJs(js: Uint8Array) {
@@ -25,7 +68,9 @@ async function runJs(js: Uint8Array) {
     }),
   );
   const oldLog = globalThis.console.log;
-  globalThis.console.log = (arg) => {
+  globalThis.console.log = (...args: unknown[]) => {
+    const arg =
+      args.length <= 1 ? args[0] : args.map((v) => String(v)).join(" ");
     self.postMessage(arg);
   };
   try {
@@ -34,6 +79,188 @@ async function runJs(js: Uint8Array) {
     self.postMessage(e);
     return;
   } finally {
+    URL.revokeObjectURL(jsUrl);
+    globalThis.console.log = oldLog;
+  }
+  self.postMessage(null);
+}
+
+function traceKey(
+  trace: Pick<
+    TraceResult,
+    "name" | "line" | "start_column" | "end_column" | "filepath"
+  >,
+): string {
+  return JSON.stringify({
+    name: trace.name,
+    line: trace.line,
+    start_column: trace.start_column,
+    end_column: trace.end_column,
+    filepath: trace.filepath ?? "",
+  });
+}
+
+type WorkerTraceParseState = {
+  section: "stdout" | "meta" | "value";
+  pendingChunkLine: string;
+  pendingValueLines: string[];
+  lastResultKey: string | undefined;
+  results: Map<string, TraceResult>;
+  pendingDeltas: Map<string, TraceResult>;
+  pendingStdout: string[];
+  flushTimer: number | undefined;
+  commitsSinceFlush: number;
+};
+
+async function runJsAggregate(js: Uint8Array) {
+  const jsUrl = URL.createObjectURL(
+    new Blob([js], {
+      type: "application/javascript",
+    }),
+  );
+  const state: WorkerTraceParseState = {
+    section: "stdout",
+    pendingChunkLine: "",
+    pendingValueLines: [],
+    lastResultKey: undefined,
+    results: new Map(),
+    pendingDeltas: new Map(),
+    pendingStdout: [],
+    flushTimer: undefined,
+    commitsSinceFlush: 0,
+  };
+  const post = (message: TraceWorkerMessage) => {
+    self.postMessage(message);
+  };
+  const flushNow = () => {
+    if (state.flushTimer !== undefined) {
+      clearTimeout(state.flushTimer);
+      state.flushTimer = undefined;
+    }
+    if (state.pendingDeltas.size > 0) {
+      post({
+        kind: "trace-delta",
+        entries: [...state.pendingDeltas.values()],
+      });
+      state.pendingDeltas.clear();
+    }
+    if (state.pendingStdout.length > 0) {
+      post({
+        kind: "stdout-batch",
+        lines: state.pendingStdout,
+      });
+      state.pendingStdout = [];
+    }
+    state.commitsSinceFlush = 0;
+  };
+  const scheduleFlush = () => {
+    if (state.flushTimer !== undefined) return;
+    state.flushTimer = setTimeout(() => {
+      flushNow();
+    }, TRACE_FLUSH_INTERVAL_MS) as unknown as number;
+  };
+  const commitTraceValue = () => {
+    if (!state.lastResultKey) return;
+    const res = state.results.get(state.lastResultKey);
+    if (!res) return;
+    res.value = state.pendingValueLines.join("\n");
+    state.pendingDeltas.set(state.lastResultKey, { ...res });
+    state.commitsSinceFlush += 1;
+    if (state.commitsSinceFlush >= TRACE_FLUSH_EVERY_COMMITS) {
+      flushNow();
+      return;
+    }
+    scheduleFlush();
+  };
+  const feedTraceLine = (line: string) => {
+    if (line === TRACING_START) {
+      state.section = "meta";
+      return;
+    }
+    if (line === TRACING_END) {
+      state.section = "stdout";
+      state.pendingValueLines = [];
+      state.lastResultKey = undefined;
+      return;
+    }
+    if (line === TRACING_CONTENT_START) {
+      state.section = "value";
+      state.pendingValueLines = [];
+      return;
+    }
+    if (line === TRACING_CONTENT_END) {
+      commitTraceValue();
+      state.section = "meta";
+      state.pendingValueLines = [];
+      return;
+    }
+    if (state.section === "value") {
+      state.pendingValueLines.push(line);
+      return;
+    }
+    if (state.section === "meta") {
+      try {
+        const j = JSON.parse(line) as Omit<TraceResult, "value" | "hit">;
+        const key = traceKey(j);
+        state.lastResultKey = key;
+        const prev = state.results.get(key);
+        if (!prev) {
+          state.results.set(key, {
+            ...j,
+            value: "",
+            hit: 1,
+          });
+        } else {
+          state.results.set(key, {
+            ...j,
+            value: prev.value,
+            hit: prev.hit + 1,
+          });
+        }
+      } catch {
+        state.pendingStdout.push(line);
+        scheduleFlush();
+      }
+      return;
+    }
+    state.pendingStdout.push(line);
+    scheduleFlush();
+  };
+  const feedTraceChunk = (chunk: string) => {
+    if (
+      !chunk.includes("\n") &&
+      !chunk.includes("\r") &&
+      state.pendingChunkLine === ""
+    ) {
+      feedTraceLine(chunk);
+      return;
+    }
+    const text = state.pendingChunkLine + chunk;
+    const lines = text.split(/\r?\n/);
+    state.pendingChunkLine = lines.pop() ?? "";
+    for (const line of lines) {
+      feedTraceLine(line);
+    }
+  };
+
+  const oldLog = globalThis.console.log;
+  globalThis.console.log = (...args: unknown[]) => {
+    const arg =
+      args.length <= 1 ? args[0] : args.map((v) => String(v)).join(" ");
+    feedTraceChunk(String(arg));
+  };
+  try {
+    await import(/* @vite-ignore */ jsUrl);
+  } catch (e) {
+    flushNow();
+    self.postMessage(e);
+    return;
+  } finally {
+    if (state.pendingChunkLine.length > 0) {
+      feedTraceLine(state.pendingChunkLine);
+      state.pendingChunkLine = "";
+    }
+    flushNow();
     URL.revokeObjectURL(jsUrl);
     globalThis.console.log = oldLog;
   }

--- a/moonpad/src/trace-types.ts
+++ b/moonpad/src/trace-types.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type TraceResult = {
+  name: string;
+  value: string;
+  line: number;
+  start_column: number;
+  end_column: number;
+  filepath?: string;
+  hit: number;
+};
+
+type TraceRunOutput =
+  | {
+      kind: "trace-delta";
+      entries: TraceResult[];
+    }
+  | {
+      kind: "stdout-batch";
+      lines: string[];
+    };
+
+export type { TraceResult, TraceRunOutput };


### PR DESCRIPTION
## Summary
- move value-trace parsing and aggregation into moonrun-worker before sending messages to UI thread
- stream aggregated trace-delta and stdout-batch messages through runTrace
- keep tracing bounded via worker-side aggregation and periodic flushes
- remove atomics/shared-buffer backpressure path from this extraction
- simplify trace request/stream flow for readability
- fix regression by preserving value-trace marker boundaries per console.log event
- restore trace-main command arg fallback (fileUri or uri) and render fallback when filtered results are empty

## Validation
- pnpm -C moonpad check
- pnpm -C moonpad build
- manual verification: value tracing works
